### PR TITLE
Add Tests For FastAPI Endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install:
 	poetry install --with dev
 
 test:
-	#poetry run pytest .
+	poetry run pytest .
 
 format:	
 	poetry run black .

--- a/api/server.py
+++ b/api/server.py
@@ -3,8 +3,7 @@ Server for inference.
 """
 
 from pydantic import BaseModel
-from fastapi import FastAPI, Request
-from fastapi.middleware.cors import CORSMiddleware
+from fastapi import FastAPI
 import uvicorn
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ pytest = "^7.4.0"
 pytest-cov = "^4.1.0"
 ruff = "^0.0.285"
 
+# Web Testing
+httpx = "^0.26.0"
+
 # PostgresSQL psycopg2 pre-compiled binary
 psycopg2-binary = "^2.9.9"
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,51 @@
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from api.server import app
+
+
+client = TestClient(app)
+
+
+def test_predict() -> None:
+    URL: str = "http://0.0.0.0:8000/api/predict"
+    QUERY_PARAM: str = "?model_name=random_model"
+    HEADERS: dict[str, str] = {
+        "Content-Type": "application/json",
+    }
+    DATA: dict[str, str] = {
+        "x": "4.0",
+        "y": "2.0",
+    }
+
+    response: Response = client.post(
+        url=URL + QUERY_PARAM,
+        json=DATA,
+        headers=HEADERS,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "model": "random_model",
+        "prediction": 8.0,
+    }
+
+
+def test_predict_bad_data() -> None:
+    URL: str = "http://0.0.0.0:8000/api/predict"
+    QUERY_PARAM: str = "?model_name=random_model"
+    HEADERS: dict[str, str] = {
+        "Content-Type": "application/json",
+    }
+    DATA: dict[str, str] = {
+        "x": "4.0",
+        "y": "hello",
+    }
+
+    response: Response = client.post(
+        url=URL + QUERY_PARAM,
+        json=DATA,
+        headers=HEADERS,
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Simple tests added for the FastAPI template.

This uses the `fastapi.testclient.TestClient` object - you can get the same behavior by spinning up a live server and writing tests with `requests`, but this simplifies your testing set up, speeds up testing, and is standard. 

## Motivation and Context

It's nice to have a starting point for testing 🦭.

## Testing

Tests written with `pytest` can be run with `make test`.

## Dependencies Added:

- `httpx`: web testing dependency in `dev` dependency group
  - `fastapi.testclient`  comes directly from `starlette` - this is a `starlette` dependency

## Dependencies Removed:

None

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- DELETE OR COMMENT OUT THE OTHER CHOICES -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (non-breaking change which improves documentation)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (or no changes needed).
- [x] I have added tests to cover my changes (or no new test are needed).
- [x] All new and existing tests are passing.
